### PR TITLE
IMEX splitting for transport/collision. 

### DIFF
--- a/pyfr/integrators/std/steppers.py
+++ b/pyfr/integrators/std/steppers.py
@@ -281,3 +281,57 @@ class StdIMEX11Stepper(BaseStdStepper):
         imex_solve(ut, t+dt, dt)
 
         return ut
+
+class StdIMEX32Stepper(BaseStdStepper):
+    stepper_name = 'imex32'
+    stepper_has_errest = False
+    stepper_nregs = 3
+    stepper_order = 2
+
+    @property
+    def _stepper_nfevals(self):
+        return self.nsteps
+
+    def step(self, t, dt):
+        syst = self.system
+        add, rhs_nosource = self._add, syst.rhs_nosource
+        limit, gtau = syst.limit, syst.gtau
+        imex_solve, gmfrcptau = syst.imex_solve, syst.gmfrcptau
+        r0, r1, r2 = self._regidx
+
+        limit(r0) # limit(fn)
+        gtau(r0) # g1 = g2 = g(f^n)
+        add(0.0, r1, 1.0, r0) # r1 = fn
+        imex_solve(r1, t+0.5*dt, 0.5*dt) # f1 = fn + 0.5*dt*(g1-f1)/tau
+        add(0.0, r2, 1.0, r1) # r2 = f1
+        gmfrcptau(r2) # r2 = (g1 - f1)/tau
+        
+        add(1.0, r1, -dt, r2) # r1 = f1 - dt*(g1 - f1)/tau = fn - 0.5*dt*(g1-f1)/tau
+        imex_solve(r1, t, 0.5*dt) # r1 = f2 = fn - 0.5*dt*(g1-f1)/tau + 0.5*dt*(g2-f2)/tau
+        limit(r1)
+        rhs_nosource(t, r1, r2) # r2 = D(f2)
+        gmfrcptau(r1) # r1 = (g2 - f2)/tau
+
+        # Collect: r0 = fn + dt*D(f2) (will subtract 0.5 later)
+        add(1.0, r0, dt, r2)
+        limit(r0)
+        gtau(r0) # g3
+
+        # r0 = fn + dt*D(f2) + 0.5*(g2 - f2)/tau
+        add(1.0, r0, 0.5*dt, r1)
+        add(0.0, r1, 1.0, r0) # r1 = r0
+        imex_solve(r1, t+dt, 0.5*dt) # r1 = f3
+
+        # r0 = fn + 0.5*dt*D(f2) + 0.5*(g2 - f2)/tau
+        add(1.0, r0, -0.5*dt, r2)
+        rhs_nosource(t, r1, r2) # r2 = D(f3)
+    
+        # r0 = fn + 0.5*dt*D(f2) + 0.5*(g2 - f2)/tau + 0.5*dt*D(f3)
+        add(1.0, r0, 0.5*dt, r2) 
+        gmfrcptau(r1) # r1 = (g3 - f3)/tau
+
+        # r0 = fn + 0.5*dt*D(f2) + 0.5*(g2 - f2)/tau + 0.5*dt*D(f3) + 0.5*(g3 - f3)/tau
+        add(1.0, r0, 0.5*dt, r1) 
+        limit(r0)
+        
+        return r0

--- a/pyfr/integrators/std/steppers.py
+++ b/pyfr/integrators/std/steppers.py
@@ -257,3 +257,27 @@ class StdRK45Stepper(StdRKVdH2RStepper):
         606302364029 / 971179775848,
         1097981568119 / 3980877426909
     ]
+
+class StdIMEX11Stepper(BaseStdStepper):
+    stepper_name = 'imex11'
+    stepper_has_errest = False
+    stepper_nregs = 2
+    stepper_order = 1
+
+    @property
+    def _stepper_nfevals(self):
+        return self.nsteps
+
+    def step(self, t, dt):
+        syst = self.system
+        add, rhs_nosource = self._add, syst.rhs_nosource
+        limit, gtau, imex_solve = syst.limit, syst.gtau, syst.imex_solve
+        ut, f = self._regidx
+
+        rhs_nosource(t, ut, f)
+        add(1.0, ut, dt, f)
+        limit(ut)
+        gtau(ut)
+        imex_solve(ut, t+dt, dt)
+
+        return ut

--- a/pyfr/integrators/std/steppers.py
+++ b/pyfr/integrators/std/steppers.py
@@ -278,7 +278,7 @@ class StdIMEX11Stepper(BaseStdStepper):
         add(1.0, ut, dt, f)
         limit(ut)
         gtau(ut)
-        imex_solve(ut, t+dt, dt)
+        imex_solve(ut, dt)
 
         return ut
 
@@ -302,12 +302,12 @@ class StdIMEX32Stepper(BaseStdStepper):
         limit(r0) # limit(fn)
         gtau(r0) # g1 = g2 = g(f^n)
         add(0.0, r1, 1.0, r0) # r1 = fn
-        imex_solve(r1, t+0.5*dt, 0.5*dt) # f1 = fn + 0.5*dt*(g1-f1)/tau
+        imex_solve(r1, 0.5*dt) # f1 = fn + 0.5*dt*(g1-f1)/tau
         add(0.0, r2, 1.0, r1) # r2 = f1
         gmfrcptau(r2) # r2 = (g1 - f1)/tau
         
         add(1.0, r1, -dt, r2) # r1 = f1 - dt*(g1 - f1)/tau = fn - 0.5*dt*(g1-f1)/tau
-        imex_solve(r1, t, 0.5*dt) # r1 = f2 = fn - 0.5*dt*(g1-f1)/tau + 0.5*dt*(g2-f2)/tau
+        imex_solve(r1, 0.5*dt) # r1 = f2 = fn - 0.5*dt*(g1-f1)/tau + 0.5*dt*(g2-f2)/tau
         limit(r1)
         rhs_nosource(t, r1, r2) # r2 = D(f2)
         gmfrcptau(r1) # r1 = (g2 - f2)/tau
@@ -317,20 +317,20 @@ class StdIMEX32Stepper(BaseStdStepper):
         limit(r0)
         gtau(r0) # g3
 
-        # r0 = fn + dt*D(f2) + 0.5*(g2 - f2)/tau
+        # r0 = fn + dt*D(f2) + 0.5*dt*(g2 - f2)/tau
         add(1.0, r0, 0.5*dt, r1)
         add(0.0, r1, 1.0, r0) # r1 = r0
-        imex_solve(r1, t+dt, 0.5*dt) # r1 = f3
+        imex_solve(r1, 0.5*dt) # r1 = f3
 
-        # r0 = fn + 0.5*dt*D(f2) + 0.5*(g2 - f2)/tau
+        # r0 = fn + 0.5*dt*D(f2) + 0.5*dt*(g2 - f2)/tau
         add(1.0, r0, -0.5*dt, r2)
         rhs_nosource(t, r1, r2) # r2 = D(f3)
     
-        # r0 = fn + 0.5*dt*D(f2) + 0.5*(g2 - f2)/tau + 0.5*dt*D(f3)
+        # r0 = fn + 0.5*dt*D(f2) + 0.5*dt*(g2 - f2)/tau + 0.5*dt*D(f3)
         add(1.0, r0, 0.5*dt, r2) 
         gmfrcptau(r1) # r1 = (g3 - f3)/tau
 
-        # r0 = fn + 0.5*dt*D(f2) + 0.5*(g2 - f2)/tau + 0.5*dt*D(f3) + 0.5*(g3 - f3)/tau
+        # r0 = fn + 0.5*dt*D(f2) + 0.5*dt*(g2 - f2)/tau + 0.5*dt*D(f3) + 0.5*dt*(g3 - f3)/tau
         add(1.0, r0, 0.5*dt, r1) 
         limit(r0)
         

--- a/pyfr/integrators/std/steppers.py
+++ b/pyfr/integrators/std/steppers.py
@@ -324,7 +324,7 @@ class StdIMEX32Stepper(BaseStdStepper):
 
         # r0 = fn + 0.5*dt*D(f2) + 0.5*dt*(g2 - f2)/tau
         add(1.0, r0, -0.5*dt, r2)
-        rhs_nosource(t, r1, r2) # r2 = D(f3)
+        rhs_nosource(t + dt, r1, r2) # r2 = D(f3)
     
         # r0 = fn + 0.5*dt*D(f2) + 0.5*dt*(g2 - f2)/tau + 0.5*dt*D(f3)
         add(1.0, r0, 0.5*dt, r2) 

--- a/pyfr/solvers/base/elements.py
+++ b/pyfr/solvers/base/elements.py
@@ -179,7 +179,7 @@ class BaseElements:
 
     @cached_property
     def optimize_memory(self):
-        return self.cfg.getbool('solver', 'optimize-memory', True)
+        return self.cfg.getbool('solver', 'optimize-memory', False)
 
     def set_backend(self, backend, nscalupts, nonce, linoff):
         self._be = backend

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -256,9 +256,12 @@ class BaseSystem:
             b.prepare(t)
 
         for b in binders:
-            b(t=t)
+            b(t=t, z=0)
 
     def _rhs_graphs(self, uinbank, foutbank):
+        pass
+
+    def _rhs_nosource_graphs(self, uinbank, foutbank):
         pass
 
     def rhs(self, t, uinbank, foutbank):
@@ -266,6 +269,13 @@ class BaseSystem:
         self._prepare_kernels(t, uinbank, foutbank)
 
         for graph in self._rhs_graphs(uinbank, foutbank):
+            self.backend.run_graph(graph)
+
+    def rhs_nosource(self, t, uinbank, foutbank):
+        self._rhs_uin_fout.add((uinbank, foutbank))
+        self._prepare_kernels(t, uinbank, foutbank)
+
+        for graph in self._rhs_nosource_graphs(uinbank, foutbank):
             self.backend.run_graph(graph)
 
     def rhs_wait_times(self):

--- a/pyfr/solvers/baseadvec/system.py
+++ b/pyfr/solvers/baseadvec/system.py
@@ -255,10 +255,10 @@ class BaseAdvectionSystem(BaseSystem):
         self.backend.run_kernels(k['eles/gmfrcptau'])
 
     # Solve semi-implicit step (f + z*g/tau)/(1 + z/tau)
-    def imex_solve(self, uinbank, t, z):
+    def imex_solve(self, uinbank, z):
         k, binders = self._get_kernels(uinbank, None)
 
         for b in binders:
-            b(t=t, z=z)
+            b(t=0, z=z)
 
         self.backend.run_kernels(k['eles/imexsolve'])

--- a/pyfr/solvers/baseadvec/system.py
+++ b/pyfr/solvers/baseadvec/system.py
@@ -5,6 +5,7 @@ from pyfr.util import memoize
 
 
 class BaseAdvectionSystem(BaseSystem):
+    # Compute df/dt = -u.grad(f) + (g-f)/tau
     @memoize
     def _rhs_graphs(self, uinbank, foutbank):
         m = self._mpireqs
@@ -120,3 +121,144 @@ class BaseAdvectionSystem(BaseSystem):
             g2.commit()
 
             return g1, g2
+
+    # Compute df*/dt = -u.grad(f)
+    @memoize
+    def _rhs_nosource_graphs(self, uinbank, foutbank):
+        m = self._mpireqs
+        k, _ = self._get_kernels(uinbank, foutbank)
+
+        def deps(dk, *names): return self._kdeps(k, dk, *names)
+
+        optimize_memory = self.cfg.getbool('solver', 'optimize-memory', True)
+
+        g1 = self.backend.graph()
+        g1.add_mpi_reqs(m['scal_fpts_recv'])
+
+        # Apply positivity-preserving limiter
+        g1.add_all(k['eles/limiter'])
+
+        # Make a copy of the solution
+        g1.add_all(k['eles/copy_soln'], deps=k['eles/limiter'])
+
+        # Compute and store macroscopic state
+        g1.add_all(k['eles/macrostate'], deps=k['eles/limiter'])
+
+        if optimize_memory:
+            # Separate interior flux calculation by dimension
+            for i in range(self.ndims):
+                if i == 0:
+                    tdeps = k['eles/limiter']
+                else:
+                    tdeps = k[f'eles/tdivtpcorf_{i-1}']
+
+                # Compute the transformed flux
+                g1.add_all(k[f'eles/tdisf_curved_{i}'] + k[f'eles/tdisf_linear_{i}'], deps=tdeps)
+
+                # Compute the transformed divergence of the partially corrected flux
+                g1.add_all(k[f'eles/tdivtpcorf_{i}'],
+                        deps=k[f'eles/tdisf_curved_{i}'] + k[f'eles/tdisf_linear_{i}'])
+                
+            # Interpolate the solution to the flux points
+            g1.add_all(k['eles/disu'], deps=k['eles/limiter'] + k[f'eles/tdivtpcorf_{self.ndims-1}'])
+
+            # Pack and send these interpolated solutions to our neighbours
+            g1.add_all(k['mpiint/scal_fpts_pack'], deps=k['eles/disu'])
+            for send, pack in zip(m['scal_fpts_send'], k['mpiint/scal_fpts_pack']):
+                g1.add_mpi_req(send, deps=[pack])
+
+            # Compute the common normal flux at our internal/boundary interfaces
+            g1.add_all(k['iint/comm_flux'],
+                    deps=k['eles/disu'] + k['mpiint/scal_fpts_pack'])
+            g1.add_all(k['bcint/comm_flux'], deps=k['eles/disu'])
+    
+            g1.commit()
+
+            g2 = self.backend.graph()
+           
+            # Compute the common normal flux at our MPI interfaces
+            g2.add_all(k['mpiint/scal_fpts_unpack'])
+            for l in k['mpiint/comm_flux']:
+                g2.add(l, deps=deps(l, 'mpiint/scal_fpts_unpack'))
+
+            # Compute the transformed divergence of the corrected flux
+            g2.add_all(k['eles/tdivtconf'], deps=k['mpiint/comm_flux'])
+
+            # Obtain the physical divergence of the corrected flux
+            for l in k['eles/negdivconf_nosource']:
+                g2.add(l, deps=deps(l, 'eles/tdivtconf', 'eles/copy_soln'))
+            g2.commit()
+
+            return g1, g2
+        else:
+            # Interpolate the solution to the flux points
+            g1.add_all(k['eles/disu'], deps=k['eles/limiter'])
+
+            # Pack and send these interpolated solutions to our neighbours
+            g1.add_all(k['mpiint/scal_fpts_pack'], deps=k['eles/disu'])
+            for send, pack in zip(m['scal_fpts_send'], k['mpiint/scal_fpts_pack']):
+                g1.add_mpi_req(send, deps=[pack])
+
+            # Compute the common normal flux at our internal/boundary interfaces
+            g1.add_all(k['iint/comm_flux'],
+                    deps=k['eles/disu'] + k['mpiint/scal_fpts_pack'])
+            g1.add_all(k['bcint/comm_flux'], deps=k['eles/disu'])
+
+            # Interpolate the solution to the quadrature points
+            g1.add_all(k['eles/qptsu'], deps=k['eles/limiter'])
+
+            # Compute the transformed flux
+            for l in k['eles/tdisf_curved'] + k['eles/tdisf_linear']:
+                g1.add(l, deps=deps(l, 'eles/qptsu', 'eles/limiter'))
+
+            # Compute the transformed divergence of the partially corrected flux
+            for l in k['eles/tdivtpcorf']:
+                ldeps = deps(l, 'eles/tdisf_curved', 'eles/tdisf_linear',
+                            'eles/copy_soln', 'eles/disu')
+                g1.add(l, deps=ldeps + k['mpiint/scal_fpts_pack'])
+
+            g1.commit()
+
+            g2 = self.backend.graph()
+
+            # Compute the common normal flux at our MPI interfaces
+            g2.add_all(k['mpiint/scal_fpts_unpack'])
+            for l in k['mpiint/comm_flux']:
+                g2.add(l, deps=deps(l, 'mpiint/scal_fpts_unpack'))
+
+            # Compute the transformed divergence of the corrected flux
+            g2.add_all(k['eles/tdivtconf'], deps=k['mpiint/comm_flux'])
+
+            # Obtain the physical divergence of the corrected flux
+            for l in k['eles/negdivconf_nosource']:
+                g2.add(l, deps=deps(l, 'eles/tdivtconf'))
+            g2.commit()
+
+            return g1, g2
+
+    # Apply limiter
+    def limit(self, uinbank):
+        k, _ = self._get_kernels(uinbank, None)
+
+        self.backend.run_kernels(k['eles/limiter'])
+
+    # Compute and store g and tau from f
+    def gtau(self, uinbank):
+        k, _ = self._get_kernels(uinbank, None)
+
+        self.backend.run_kernels(k['eles/gtau'])
+
+    # Compute (g-f)/tau with precomputed g and tau 
+    def gmfrcptau(self, uinbank):
+        k, _ = self._get_kernels(uinbank, None)
+
+        self.backend.run_kernels(k['eles/gmfrcptau'])
+
+    # Solve semi-implicit step (f + z*g/tau)/(1 + z/tau)
+    def imex_solve(self, uinbank, t, z):
+        k, binders = self._get_kernels(uinbank, None)
+
+        for b in binders:
+            b(t=t, z=z)
+
+        self.backend.run_kernels(k['eles/imexsolve'])

--- a/pyfr/solvers/bgk/elements.py
+++ b/pyfr/solvers/bgk/elements.py
@@ -370,3 +370,39 @@ class BGKElements(BaseAdvectionElements):
             dims=[self.nupts, self.neles], f=self.scal_upts[uin],
             mvars=self.mvars, u=self.umat, M=self.Mmat
         )
+
+        # Helper kernels for IMEX schemes
+        if 'imex' in self.cfg.get('solver-time-integrator', 'scheme'):
+            self._be.pointwise.register('pyfr.solvers.bgk.kernels.negdivconfbgknosource')
+            self._be.pointwise.register('pyfr.solvers.bgk.kernels.gtau')
+            self._be.pointwise.register('pyfr.solvers.bgk.kernels.gmfrcptau')
+            self._be.pointwise.register('pyfr.solvers.bgk.kernels.imexsolve')
+
+            # Compute and store g and tau
+            self.g = self._be.matrix((self.nupts, self.nvars, self.neles),
+                                    extent=nonce + 'g', tags={'align'})
+            self.kernels['gtau'] = lambda uin : self._be.kernel(
+                'gtau', tplargs=tplargs, dims=[self.nupts, self.neles],
+                f=self.scal_upts[uin], g=self.g, u=self.umat, M=self.Mmat,
+                tau=self.tau
+            )
+
+            # Take in f and tau and g (stored from gtau kernel) and compute (g-f)/tau
+            self.kernels['gmfrcptau'] = lambda uin: self._be.kernel(
+                'gmfrcptau', tplargs=tplargs, dims=[self.nupts, self.neles],
+                f=self.scal_upts[uin], g=self.g, tau=self.tau
+            )
+
+            # Solve semi-implicit step (f + z*g/tau)/(1 + z/tau), where
+            # z is an extern and g and tau are stored from gtau kernel
+            self.kernels['imexsolve'] = lambda uin: self._be.kernel(
+                'imexsolve', tplargs=tplargs, dims=[self.nupts, self.neles],
+                f=self.scal_upts[uin], g=self.g, tau=self.tau
+            )
+
+            # Compute RHS without collision (-u.grad(f))
+            self.kernels['negdivconf_nosource'] = lambda fout: self._be.kernel(
+                'negdivconfbgknosource', tplargs=tplargs,
+                dims=[self.nupts, self.neles], tdivtconf=self.scal_upts[fout],
+                rcpdjac=self.rcpdjac_at('upts'), ploc=plocupts
+            )

--- a/pyfr/solvers/bgk/elements.py
+++ b/pyfr/solvers/bgk/elements.py
@@ -256,6 +256,10 @@ class BGKElements(BaseAdvectionElements):
         self.umat = self._be.const_matrix(self.u)
         self.Mmat = self._be.const_matrix(np.reshape(self.M, (1, -1)))
         self.niters = self.cfg.getint('solver', 'niters')
+        
+        # Allocate space for the collision time vector
+        self.tau = self._be.matrix((self.nupts, self.neles),
+                                   extent=nonce + 'tau', tags={'align'})
 
         # Get solver constants
         tau_ref = self.cfg.getfloat('constants', 'tau_ref')
@@ -337,7 +341,7 @@ class BGKElements(BaseAdvectionElements):
     
         self.kernels['collision'] = lambda : self._be.kernel(
             'collision', tplargs=tplargs, dims=[self.nupts, self.neles],
-            f=self._scal_upts_cpy, u=self.umat, M=self.Mmat
+            f=self._scal_upts_cpy, u=self.umat, M=self.Mmat, tau=self.tau
         )
     
         self.kernels['negdivconf'] = lambda fout: self._be.kernel(

--- a/pyfr/solvers/bgk/kernels/collision.mako
+++ b/pyfr/solvers/bgk/kernels/collision.mako
@@ -19,41 +19,18 @@
     fpdtype_t q[${ndims+2}] = {0};
     ${pyfr.expand('con_to_pri', 'w', 'q')};
 
-    // Apply ES-BGK model if necessary
-    % if Pr != 1:
-    // Compute initial temperature tensor (scaled by 1 - 1/Pr)
-    fpdtype_t T[${ndims}][${ndims}] = {{0}};
-    ${pyfr.expand('compute_temperature_tensor', 'T', 'f', 'q', 'u', 'M')}; 
-
-    // Get alpha vector
-    fpdtype_t alpha[${ndims+2}], Tvinv[${ndims}][${ndims}] = {{0}};
-    ${pyfr.expand('compute_alpha_ellipsoidal', 'q', 'T', 'Tvinv', 'alpha')};
-
-    // Compute discretely conservative equilibrium state
-    ${pyfr.expand('iterate_DVM_ESBGK', 'alpha', 'w', 'T', 'Tvinv', 'u', 'M')};
-    % else:
-    // Get alpha vector
+    // Compute equilibrium distribution function via DVM
     fpdtype_t alpha[${ndims+2}];
-    ${pyfr.expand('compute_alpha_Gaussian', 'q', 'alpha')};
-
-    // Compute discretely conservative equilibrium state
-    ${pyfr.expand('iterate_DVM_BGK', 'alpha', 'w', 'u', 'M')};
+    % if Pr != 1:
+    fpdtype_t Tvinv[${ndims}][${ndims}] = {{0}};
+    ${pyfr.expand('iterate_alpha_ESBGK', 'w', 'q', 'u', 'M', 'Tvinv', 'alpha')};
+    % else:
+    ${pyfr.expand('iterate_alpha_BGK', 'w', 'q', 'u', 'M', 'alpha')};
     % endif
 
     // Compute collision time based on viscosity model
-    fpdtype_t p = q[${ndims+1}];
-    fpdtype_t theta = p/q[0];
-    % if viscosity_law == 'constant-tau':
-    tau = ${tau_ref/Pr};
-    % elif viscosity_law == 'constant-viscosity':
-    tau = ${tau_ref*P_ref/Pr}/p;
-    % elif viscosity_law == 'power-law':
-    tau = ${tau_ref/Pr}*pow(theta/${theta_ref}, ${omega})/(p/${P_ref});
-    % elif viscosity_law == 'sutherland':
-    // mu = mu_ref*(T/T_ref)^1.5 * (T_ref + T_s)/(T + T_s)
-    fpdtype_t theta_rat = theta/${theta_ref};
-    tau = (${tau_ref*P_ref*(theta_ref + theta_s)/Pr}/p)*theta_rat*sqrt(theta_rat)/(theta + ${theta_s});
-    % endif
+    fpdtype_t theta;
+    ${pyfr.expand('compute_tau', 'q', 'theta', 'tau')};
 
     // Set source term
     fpdtype_t g;

--- a/pyfr/solvers/bgk/kernels/collision.mako
+++ b/pyfr/solvers/bgk/kernels/collision.mako
@@ -8,7 +8,8 @@
               t='scalar fpdtype_t'
               f='inout fpdtype_t[${str(nvars)}]'
               u='in broadcast fpdtype_t[${str(nuvars)}][${str(ndims)}]'
-              M='in broadcast fpdtype_t[1][${str(nuvars)}]'>
+              M='in broadcast fpdtype_t[1][${str(nuvars)}]'
+              tau='out fpdtype_t'>
 
     // Navier-Stokes conserved variables
     fpdtype_t w[${ndims+2}] = {0};
@@ -43,15 +44,15 @@
     fpdtype_t p = q[${ndims+1}];
     fpdtype_t theta = p/q[0];
     % if viscosity_law == 'constant-tau':
-    fpdtype_t tau = ${tau_ref/Pr};
+    tau = ${tau_ref/Pr};
     % elif viscosity_law == 'constant-viscosity':
-    fpdtype_t tau = ${tau_ref*P_ref/Pr}/p;
+    tau = ${tau_ref*P_ref/Pr}/p;
     % elif viscosity_law == 'power-law':
-    fpdtype_t tau = ${tau_ref/Pr}*pow(theta/${theta_ref}, ${omega})/(p/${P_ref});
+    tau = ${tau_ref/Pr}*pow(theta/${theta_ref}, ${omega})/(p/${P_ref});
     % elif viscosity_law == 'sutherland':
     // mu = mu_ref*(T/T_ref)^1.5 * (T_ref + T_s)/(T + T_s)
     fpdtype_t theta_rat = theta/${theta_ref};
-    fpdtype_t tau = (${tau_ref*P_ref*(theta_ref + theta_s)/Pr}/p)*theta_rat*sqrt(theta_rat)/(theta + ${theta_s});
+    tau = (${tau_ref*P_ref*(theta_ref + theta_s)/Pr}/p)*theta_rat*sqrt(theta_rat)/(theta + ${theta_s});
     % endif
 
     // Set source term

--- a/pyfr/solvers/bgk/kernels/gmfrcptau.mako
+++ b/pyfr/solvers/bgk/kernels/gmfrcptau.mako
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+<%inherit file='base'/>
+<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
+
+<%pyfr:kernel name='gmfrcptau' ndim='2'
+              t='scalar fpdtype_t'
+              f='inout fpdtype_t[${str(nvars)}]'
+              g='in fpdtype_t[${str(nvars)}]'
+              tau='in fpdtype_t'>
+
+    for (int i = 0; i < ${nvars}; i++) {
+        f[i] = (g[i] - f[i])/tau;
+    }
+</%pyfr:kernel>

--- a/pyfr/solvers/bgk/kernels/gtau.mako
+++ b/pyfr/solvers/bgk/kernels/gtau.mako
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+<%inherit file='base'/>
+<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
+
+<%include file='pyfr.solvers.bgk.kernels.util'/>
+
+<%pyfr:kernel name='gtau' ndim='2'
+              t='scalar fpdtype_t'
+              f='in fpdtype_t[${str(nvars)}]'
+              u='in broadcast fpdtype_t[${str(nuvars)}][${str(ndims)}]'
+              M='in broadcast fpdtype_t[1][${str(nuvars)}]'
+              g='out fpdtype_t[${str(nvars)}]'
+              tau='out fpdtype_t'>
+
+    // Navier-Stokes conserved variables
+    fpdtype_t w[${ndims+2}] = {0};
+    ${pyfr.expand('compute_moments', 'f', 'u', 'M', 'w')};
+
+    // Convert to primitives
+    fpdtype_t q[${ndims+2}] = {0};
+    ${pyfr.expand('con_to_pri', 'w', 'q')};
+
+    // Apply ES-BGK model if necessary
+    % if Pr != 1:
+    // Compute initial temperature tensor (scaled by 1 - 1/Pr)
+    fpdtype_t T[${ndims}][${ndims}] = {{0}};
+    ${pyfr.expand('compute_temperature_tensor', 'T', 'f', 'q', 'u', 'M')}; 
+
+    // Get alpha vector
+    fpdtype_t alpha[${ndims+2}], Tvinv[${ndims}][${ndims}] = {{0}};
+    ${pyfr.expand('compute_alpha_ellipsoidal', 'q', 'T', 'Tvinv', 'alpha')};
+
+    // Compute discretely conservative equilibrium state
+    ${pyfr.expand('iterate_DVM_ESBGK', 'alpha', 'w', 'T', 'Tvinv', 'u', 'M')};
+    % else:
+    // Get alpha vector
+    fpdtype_t alpha[${ndims+2}];
+    ${pyfr.expand('compute_alpha_Gaussian', 'q', 'alpha')};
+
+    // Compute discretely conservative equilibrium state
+    ${pyfr.expand('iterate_DVM_BGK', 'alpha', 'w', 'u', 'M')};
+    % endif
+
+    // Compute collision time based on viscosity model
+    fpdtype_t p = q[${ndims+1}];
+    fpdtype_t theta = p/q[0];
+    % if viscosity_law == 'constant-tau':
+    tau = ${tau_ref/Pr};
+    % elif viscosity_law == 'constant-viscosity':
+    tau = ${tau_ref*P_ref/Pr}/p;
+    % elif viscosity_law == 'power-law':
+    tau = ${tau_ref/Pr}*pow(theta/${theta_ref}, ${omega})/(p/${P_ref});
+    % elif viscosity_law == 'sutherland':
+    // mu = mu_ref*(T/T_ref)^1.5 * (T_ref + T_s)/(T + T_s)
+    fpdtype_t theta_rat = theta/${theta_ref};
+    tau = (${tau_ref*P_ref*(theta_ref + theta_s)/Pr}/p)*theta_rat*sqrt(theta_rat)/(theta + ${theta_s});
+    % endif
+
+    // Set source term
+    fpdtype_t gi;
+    for (int i = 0; i < ${nuvars}; i++) {
+        // Compute equilibrium distribution at i-th velocity point
+        % if Pr != 1:
+        ${pyfr.expand('compute_ellipsoidal_distribution', 'alpha', 'u[i]', 'Tvinv', 'gi')};
+        % else:
+        ${pyfr.expand('compute_Maxwellian_distribution', 'alpha', 'u[i]', 'gi')};
+        % endif
+
+        // Set source
+        g[i] = gi;
+        % if delta:
+        g[i + ${nuvars}] = (${delta/2.0}*theta*gi);
+        % endif
+    }
+</%pyfr:kernel>

--- a/pyfr/solvers/bgk/kernels/gtau.mako
+++ b/pyfr/solvers/bgk/kernels/gtau.mako
@@ -20,41 +20,18 @@
     fpdtype_t q[${ndims+2}] = {0};
     ${pyfr.expand('con_to_pri', 'w', 'q')};
 
-    // Apply ES-BGK model if necessary
-    % if Pr != 1:
-    // Compute initial temperature tensor (scaled by 1 - 1/Pr)
-    fpdtype_t T[${ndims}][${ndims}] = {{0}};
-    ${pyfr.expand('compute_temperature_tensor', 'T', 'f', 'q', 'u', 'M')}; 
-
-    // Get alpha vector
-    fpdtype_t alpha[${ndims+2}], Tvinv[${ndims}][${ndims}] = {{0}};
-    ${pyfr.expand('compute_alpha_ellipsoidal', 'q', 'T', 'Tvinv', 'alpha')};
-
-    // Compute discretely conservative equilibrium state
-    ${pyfr.expand('iterate_DVM_ESBGK', 'alpha', 'w', 'T', 'Tvinv', 'u', 'M')};
-    % else:
-    // Get alpha vector
+    // Compute equilibrium distribution function via DVM
     fpdtype_t alpha[${ndims+2}];
-    ${pyfr.expand('compute_alpha_Gaussian', 'q', 'alpha')};
-
-    // Compute discretely conservative equilibrium state
-    ${pyfr.expand('iterate_DVM_BGK', 'alpha', 'w', 'u', 'M')};
+    % if Pr != 1:
+    fpdtype_t Tvinv[${ndims}][${ndims}] = {{0}};
+    ${pyfr.expand('iterate_alpha_ESBGK', 'w', 'q', 'u', 'M', 'Tvinv', 'alpha')};
+    % else:
+    ${pyfr.expand('iterate_alpha_BGK', 'w', 'q', 'u', 'M', 'alpha')};
     % endif
 
     // Compute collision time based on viscosity model
-    fpdtype_t p = q[${ndims+1}];
-    fpdtype_t theta = p/q[0];
-    % if viscosity_law == 'constant-tau':
-    tau = ${tau_ref/Pr};
-    % elif viscosity_law == 'constant-viscosity':
-    tau = ${tau_ref*P_ref/Pr}/p;
-    % elif viscosity_law == 'power-law':
-    tau = ${tau_ref/Pr}*pow(theta/${theta_ref}, ${omega})/(p/${P_ref});
-    % elif viscosity_law == 'sutherland':
-    // mu = mu_ref*(T/T_ref)^1.5 * (T_ref + T_s)/(T + T_s)
-    fpdtype_t theta_rat = theta/${theta_ref};
-    tau = (${tau_ref*P_ref*(theta_ref + theta_s)/Pr}/p)*theta_rat*sqrt(theta_rat)/(theta + ${theta_s});
-    % endif
+    fpdtype_t theta;
+    ${pyfr.expand('compute_tau', 'q', 'theta', 'tau')};
 
     // Set source term
     fpdtype_t gi;

--- a/pyfr/solvers/bgk/kernels/imexsolve.mako
+++ b/pyfr/solvers/bgk/kernels/imexsolve.mako
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+<%inherit file='base'/>
+<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
+
+<%pyfr:kernel name='imexsolve' ndim='2'
+              t='scalar fpdtype_t'
+              z='scalar fpdtype_t'
+              f='inout fpdtype_t[${str(nvars)}]'
+              g='in fpdtype_t[${str(nvars)}]'
+              tau='in fpdtype_t'>
+
+    for (int i = 0; i < ${nvars}; i++) {
+        f[i] = (f[i]*tau + z*g[i])/(tau + z);
+    }
+</%pyfr:kernel>

--- a/pyfr/solvers/bgk/kernels/negdivconfbgknosource.mako
+++ b/pyfr/solvers/bgk/kernels/negdivconfbgknosource.mako
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+<%inherit file='base'/>
+<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
+
+<%pyfr:kernel name='negdivconfbgknosource' ndim='2'
+              t='scalar fpdtype_t'
+              tdivtconf='inout fpdtype_t[${str(nvars)}]'
+              rcpdjac='in fpdtype_t'>
+
+// Compute advection component df/dt = -u.div(f)
+for (int i = 0; i < ${nvars}; i++) {
+    tdivtconf[i] = -rcpdjac*tdivtconf[i];
+}
+</%pyfr:kernel>

--- a/pyfr/solvers/bgk/kernels/util.mako
+++ b/pyfr/solvers/bgk/kernels/util.mako
@@ -390,5 +390,39 @@
     }
 </%pyfr:macro>
 
+<%pyfr:macro name='compute_tau' params='q, theta, tau'>
+    fpdtype_t p = q[${ndims+1}];
+    theta = p/q[0];
+    % if viscosity_law == 'constant-tau':
+    tau = ${tau_ref/Pr};
+    % elif viscosity_law == 'constant-viscosity':
+    tau = ${tau_ref*P_ref/Pr}/p;
+    % elif viscosity_law == 'power-law':
+    tau = ${tau_ref/Pr}*pow(theta/${theta_ref}, ${omega})/(p/${P_ref});
+    % elif viscosity_law == 'sutherland':
+    // mu = mu_ref*(T/T_ref)^1.5 * (T_ref + T_s)/(T + T_s)
+    fpdtype_t theta_rat = theta/${theta_ref};
+    tau = (${tau_ref*P_ref*(theta_ref + theta_s)/Pr}/p)*theta_rat*sqrt(theta_rat)/(theta + ${theta_s});
+    % endif
+</%pyfr:macro>
 
+<%pyfr:macro name='iterate_alpha_BGK' params='w, q, u, M, alpha'>
+    // Get alpha vector
+    ${pyfr.expand('compute_alpha_Gaussian', 'q', 'alpha')};
+
+    // Compute discretely conservative equilibrium state
+    ${pyfr.expand('iterate_DVM_BGK', 'alpha', 'w', 'u', 'M')};
+</%pyfr:macro>
+
+<%pyfr:macro name='iterate_alpha_ESBGK' params='w, q, u, M, Tvinv, alpha'>
+    // Compute initial temperature tensor (scaled by 1 - 1/Pr)
+    fpdtype_t T[${ndims}][${ndims}] = {{0}};
+    ${pyfr.expand('compute_temperature_tensor', 'T', 'f', 'q', 'u', 'M')}; 
+
+    // Get alpha vector
+    ${pyfr.expand('compute_alpha_ellipsoidal', 'q', 'T', 'Tvinv', 'alpha')};
+
+    // Compute discretely conservative equilibrium state
+    ${pyfr.expand('iterate_DVM_ESBGK', 'alpha', 'w', 'T', 'Tvinv', 'u', 'M')};
+</%pyfr:macro>
 


### PR DESCRIPTION
PR adds IMEX11 (semi-implicit Euler) and IMEX32 (three-stage, second-order semi-implicit) schemes for transport/collision splitting. 